### PR TITLE
Correct blueprint example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ fields:
   text:
     type: blocks
     fieldsets:
-      - block
+      - form
       ...
 ```
 


### PR DESCRIPTION
The example for the blueprint in the README has a minimal but probably confusing typo. It shows adding a fieldset called `block` instead of `form`. I fixed that.

ps. No idea why the last line of the readme shows up as a change. Didn't do anything on that.