### PR TITLE
Add honeypot field

### DIFF
--- a/blueprints/snippets/form_options.yml
+++ b/blueprints/snippets/form_options.yml
@@ -31,3 +31,19 @@ fatal_message:
 send_button:
   label: form.block.options.send_button
   type: text
+
+honeypot:
+  type: toggle
+  label: form.block.options.honeypot
+  width: 1/3
+  default: false
+
+honeypot_name:
+  type: text
+  label: form.block.options.honeypot_name
+  width: 2/3
+  required: true
+  default: "website"
+  placeholder: "website"
+  when:
+    honeypot: true

--- a/lib/languages/de.php
+++ b/lib/languages/de.php
@@ -89,6 +89,8 @@ return [
 	'form.block.options'   					=> 'Sendeoptionen',
 	'form.block.options.info'   			=> "**Mit *\{\{  \}\}* können Sie eingehende Werte mittels Bezeichner einfügen.**\n",
 	'form.block.options.enable_notify'   	=> "Benachrichtigung senden",
+    'form.block.options.honeypot'           => "Honeypot Spamschutz",
+    'form.block.options.honeypot_name'      => "Honeypot Feldname",
 	'form.block.options.notify_email'		=> "Empfängeradresse",
 	'form.block.options.notify_subject'		=> "Betreffzeile",
 	'form.block.options.notify_body'		=> "Nachricht",

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -88,6 +88,8 @@ return [
 
 	'form.block.options' 						=> 'Options',
 	'form.block.options.enable_notify' 			=> "Send notification",
+    'form.block.options.honeypot'               => "Honeypot spam protection",
+    'form.block.options.honeypot_name'          => "Honeypot field name",
 	'form.block.options.notify_email' 			=> "Recipient address",
 	'form.block.options.notify_subject' 		=> "Subject",
 	'form.block.options.notify_body' 			=> "Message",

--- a/lib/templates/UIKit/form.php
+++ b/lib/templates/UIKit/form.php
@@ -4,6 +4,13 @@
 
 		<div class="form-block" uk-grid>
 
+            <?php if($form->honeypot()->isTrue()) : ?>
+                <div class="form-block-honeypot" style="position: absolute; left: -9999px;">
+                    <label for="form-<?= $form->id() ?>-<?= $form->honeypot_name() ?>">Website <abbr title="required">*</abbr></label>
+                    <input type="url" id="form-<?= $form->id() ?>-<?= $form->honeypot_name() ?>" name="<?= $form->honeypot_name() ?>" tabindex="-1" aria-hidden="true">
+                </div>
+            <?php endif ?>
+
 			<?php foreach ($form->fields() as $field) : ?>
 
 				<div class="form-block-field form-block-field-<?= $field->type(true) ?> uk-width-1-1 uk-width-<?= $field->width('dash') ?>@m" id="<?= $field->slug() ?>">

--- a/lib/templates/kirby-starterkit/form.php
+++ b/lib/templates/kirby-starterkit/form.php
@@ -4,6 +4,13 @@
 
 		<div class="form-block grid">
 
+            <?php if($form->honeypot()->isTrue()) : ?>
+                <div class="form-block-honeypot" style="position: absolute; left: -9999px;">
+                    <label for="form-<?= $form->id() ?>-<?= $form->honeypot_name() ?>">Website <abbr title="required">*</abbr></label>
+                    <input type="url" id="form-<?= $form->id() ?>-<?= $form->honeypot_name() ?>" name="<?= $form->honeypot_name() ?>" tabindex="-1" aria-hidden="true">
+                </div>
+            <?php endif ?>
+
 			<?php foreach ($form->fields() as $field) : ?>
 
 				<div class="form-block-field form-block-field-<?= $field->type(true) ?> column" style="--columns: <?= $field->width('grid') ?>" id="<?= $field->slug() ?>">

--- a/snippets/blocks/form.php
+++ b/snippets/blocks/form.php
@@ -4,6 +4,13 @@
 
 		<div class="form-block" style="display:grid;grid-gap: 1em 0.5em; grid-template-columns: repeat(12, 1fr);" >
 
+            <?php if($form->honeypot()->isTrue()) : ?>
+                <div class="form-block-honeypot" style="position: absolute; left: -9999px;">
+                    <label for="form-<?= $form->id() ?>-<?= $form->honeypot_name() ?>">Website <abbr title="required">*</abbr></label>
+                    <input type="url" id="form-<?= $form->id() ?>-<?= $form->honeypot_name() ?>" name="<?= $form->honeypot_name() ?>" tabindex="-1" aria-hidden="true">
+                </div>
+            <?php endif ?>
+
 			<?php foreach ($form->fields() as $field) : ?>
 				<div
 					class="form-block-field form-block-field-<?= $field->type(true) ?>"


### PR DESCRIPTION
This is a WIP for #4. At this moment, this only adds the form field option to activate the honeypot field and set its name (default is "website", but it can be overwritten in case a website field leads to conflicts with other form fields), and renders it to the frontend.

The validation is not implemented yet, as that part I didn't figure out yet how it works in the plugin.

resolves #4