### PR TITLE
Null check before and while trying to parse fields

### DIFF
--- a/classes/Form.php
+++ b/classes/Form.php
@@ -126,7 +126,11 @@ class Form extends Block
      */
     private function parseString($value): string
     {
-        return (is_string($value)) ? $value : $value->value();
+        if (!(is_null($value))) {
+            return (is_string($value)) ? $value : $value->value();
+        }
+
+        return null;
     }
 
     /**
@@ -143,15 +147,19 @@ class Form extends Block
             return $this->fields()->$slug();
         }
         
-        if (!is_array($attrs)) {
-            return $this->parseString($this->fields->$slug()->$attrs());
-        } else {
-            $result = [];
-            foreach ($attrs as $attr) {
-                $result[$attr] = $this->parseString($this->fields->$slug()->$attr());
+        if ($field = $this->fields->$slug()) {
+            if (!is_array($attrs)) {
+                return $this->parseString($field->$attrs());
+            } else {
+                $result = [];
+                foreach ($attrs as $attr) {
+                    $result[$attr] = $this->parseString($field->$attr());
+                }
+                return $result;
             }
-            return $result;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
Resolve an issue creating an exception when there is no
field with the name "email" in the form.

resolves #11

## Background

The form logic currently assumes that there will be a field with the name "email" in the form, which is used to set the reply-to email in the notification sender, and other values in the confirmation sender. When the field is not present, the parseString function tries to get the value via `value()`, but fails when this field doesn't exist.

With the additional null checks in the parseString function and before even calling the function in the `field()` function, we ensure those functions can successfully return a null value in case the requested field doesn't exist.