### PR TITLE
Apply anchor id for success and error HTML elements

### DIFF
--- a/lib/templates/UIKit/form.php
+++ b/lib/templates/UIKit/form.php
@@ -33,7 +33,7 @@
 
 <?php if ($form->isFatal()) : ?>
 
-	<div class="uk-width-1-1">
+	<div id="<?= $form->id() ?>" class="uk-width-1-1">
 		<div class="uk-alert-danger form-block-message form-block-error" uk-alert>
 			<?= $form->errorMessage() ?>
 		</div>
@@ -43,7 +43,7 @@
 
 <?php if ($form->isSuccess()) : ?>
 
-	<div class="uk-width-1-1">
+	<div id="<?= $form->id() ?>" class="uk-width-1-1">
 		<div class="uk-alert-success form-block-message form-block-success" uk-alert>
 			<?= $form->successMessage() ?>
 		</div>

--- a/lib/templates/kirby-starterkit/form.php
+++ b/lib/templates/kirby-starterkit/form.php
@@ -36,13 +36,13 @@
 
 
 <?php if ($form->isFatal()) : ?>
-	<div class="form-block-message form-block-fatal column">
+	<div id="<?= $form->id() ?>" class="form-block-message form-block-fatal column">
 		<?= $form->errorMessage() ?>
 	</div>
 <?php endif ?>
 
 <?php if ($form->isSuccess()) : ?>
-	<div class="form-block-message form-block-success column">
+	<div id="<?= $form->id() ?>" class="form-block-message form-block-success column">
 		<?= $form->successMessage() ?>
 	</div>
 <?php endif ?>

--- a/snippets/blocks/form.php
+++ b/snippets/blocks/form.php
@@ -35,13 +35,13 @@
 <?php endif ?>
 
 <?php if ($form->isFatal()) : ?>
-	<div class="form-block-message form-block-fatal column">
+	<div id="<?= $form->id() ?>" class="form-block-message form-block-fatal column">
 		<?= $form->errorMessage() ?>
 	</div>
 <?php endif ?>
 
 <?php if ($form->isSuccess()) : ?>
-	<div class="form-block-message form-block-success column">
+	<div id="<?= $form->id() ?>" class="form-block-message form-block-success column">
 		<?= $form->successMessage() ?>
 	</div>
 <?php endif ?>


### PR DESCRIPTION
Ensure the document is scrolling down to the form when there is a fatal
error and after the form is successfully submitted.

As usual, please test the changes.