### PR TITLE
Remove empty spaces from textarea

### DIFF
--- a/snippets/blocks/formfields/textarea.php
+++ b/snippets/blocks/formfields/textarea.php
@@ -6,6 +6,4 @@
     <?= $formfield->required('attr') ?>
     <?= $formfield->ariaAttr() ?>
     <?= $formfield->autofill(true) ?>
->
-    <?= $formfield->value() ?>
-</textarea>
+><?= $formfield->value() ?></textarea>


### PR DESCRIPTION
the indentation in the textarea field is added into the value of it and users need to delete the spaces before entering their own text

This PR removes the empty spaces from the textarea

<img width="60" alt="image" src="https://user-images.githubusercontent.com/6684137/178788214-8173216e-2f2e-41d5-9080-b9afe5a2ff3e.png">
