### PR TITLE
fix `Undefined array key 1` error in `honeypotId`

### DIFF
--- a/classes/Form.php
+++ b/classes/Form.php
@@ -233,7 +233,7 @@ class Form extends Block
             $out = array_diff($out, [$field->autofill(), $field->slug()]);
         }
 
-        return count($out) > 0 ? $out[1] : "honeypot";
+        return count($out) > 0 ? array_values($out)[0] : "honeypot";
     }
 
     /************************/


### PR DESCRIPTION
if the "honeypot id variant" `name` is taken by a used field, line [236](https://github.com/youngcut/kirby-form-blocks/blob/2.0.2/classes/Form.php#L236) throws an error telling you `Undefined array key 1`. This is because `array_diff` leaves key=>value associations intact, therefore the key `1`, when removed, is left "unset" (the array then goes: `0, 2, 3, 4`...). 

`array_values($out)[0]` reindexes the array, so index `0` will always be defined (if there are elements in the array).